### PR TITLE
fix: spellcheck reactivity

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "spellcheck-toggler",
 	"name": "Spellcheck Toggler",
-	"version": "1.4.0",
+	"version": "1.4.1",
 	"minAppVersion": "1.5.3",
 	"description": "Toggle spellchecking for types of text blocks in the editing view.",
 	"author": "Julian Szachowicz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "obsidian-spellcheck-toggler",
-    "version": "1.1.0",
+    "version": "1.4.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "obsidian-spellcheck-toggler",
-            "version": "1.1.0",
+            "version": "1.4.0",
             "license": "MIT",
             "dependencies": {
                 "@codemirror/language": "^6.10.1"
@@ -1773,10 +1773,11 @@
             "peer": true
         },
         "node_modules/obsidian": {
-            "version": "1.4.11",
-            "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.4.11.tgz",
-            "integrity": "sha512-BCVYTvaXxElJMl6MMbDdY/CGK+aq18SdtDY/7vH8v6BxCBQ6KF4kKxL0vG9UZ0o5qh139KpUoJHNm+6O5dllKA==",
+            "version": "1.8.7",
+            "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.8.7.tgz",
+            "integrity": "sha512-h4bWwNFAGRXlMlMAzdEiIM2ppTGlrh7uGOJS6w4gClrsjc+ei/3YAtU2VdFUlCiPuTHpY4aBpFJJW75S1Tl/JA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@types/codemirror": "5.60.8",
                 "moment": "2.29.4"
@@ -3456,9 +3457,9 @@
             "peer": true
         },
         "obsidian": {
-            "version": "1.4.11",
-            "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.4.11.tgz",
-            "integrity": "sha512-BCVYTvaXxElJMl6MMbDdY/CGK+aq18SdtDY/7vH8v6BxCBQ6KF4kKxL0vG9UZ0o5qh139KpUoJHNm+6O5dllKA==",
+            "version": "1.8.7",
+            "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.8.7.tgz",
+            "integrity": "sha512-h4bWwNFAGRXlMlMAzdEiIM2ppTGlrh7uGOJS6w4gClrsjc+ei/3YAtU2VdFUlCiPuTHpY4aBpFJJW75S1Tl/JA==",
             "dev": true,
             "requires": {
                 "@types/codemirror": "5.60.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "obsidian-spellcheck-toggler",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "description": "A plugin for Obsidian which gives you more control over the red underline spellcheck behaviour.",
     "main": "main.js",
     "scripts": {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,4 +1,4 @@
-import { EventRef, Plugin, TFile } from 'obsidian'
+import { EventRef, Plugin, TFile, parseFrontMatterStringArray } from 'obsidian'
 import { Extension } from '@codemirror/state'
 
 import {
@@ -136,8 +136,6 @@ export class SpellcheckTogglerPlugin extends Plugin {
     }
 
     onFileOpen(file: TFile | null) {
-        console.log('[spellcheck-toggler] opened file')
-
         if (file === null) return
 
         const metadata = this.app.metadataCache.getFileCache(file)
@@ -151,23 +149,23 @@ export class SpellcheckTogglerPlugin extends Plugin {
     }
 
     onFileModify(file: TFile | null) {
-        console.log('[spellcheck-toggler] modified file')
-
         if (
+            !this.settings.useReactiveFrontmatter ||
             file === null ||
             this.app.workspace.getActiveFile()?.basename !== file.basename
         )
             return
 
+            
         this.app.fileManager.processFrontMatter(file, (frontmatter) => {
-            const didDiffer = updateFrontmatterWithDifference(frontmatter)
-            if (!didDiffer) return
+            // const didDiffer = updateFrontmatterWithDifference(frontmatter)
+            // if (!didDiffer) return
 
-            this.handleSpellcheckAttribute()
-            const editor = this.app.workspace.activeEditor?.editor
-            if (!editor) return
-            editor.replaceRange(' ', editor.getCursor())
-            editor.undo()
+            // this.handleSpellcheckAttribute()
+            // const editor = this.app.workspace.activeEditor?.editor
+            // if (!editor) return
+            // editor.replaceRange(' ', editor.getCursor())
+            // editor.undo()
         })
     }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -24,6 +24,7 @@ export interface SpellcheckOption {
 }
 
 export interface SpellcheckTogglerSettings {
+    useReactiveFrontmatter: boolean
     externalLinks: SpellcheckOption
     internalLinks: SpellcheckOption
     htmlComments: SpellcheckOption
@@ -34,6 +35,7 @@ export interface SpellcheckTogglerSettings {
 }
 
 export const defaultSettings: SpellcheckTogglerSettings = {
+    useReactiveFrontmatter: false,
     externalLinks: { behaviour: SpellcheckBehaviourOption.GLOBAL },
     internalLinks: { behaviour: SpellcheckBehaviourOption.GLOBAL },
     htmlComments: { behaviour: SpellcheckBehaviourOption.DEFAULT },
@@ -42,6 +44,15 @@ export const defaultSettings: SpellcheckTogglerSettings = {
     strong: { behaviour: SpellcheckBehaviourOption.DEFAULT },
     blockquote: { behaviour: SpellcheckBehaviourOption.DEFAULT },
 }
+
+type OptionKey =
+    | 'externalLinks'
+    | 'internalLinks'
+    | 'htmlComments'
+    | 'anyNode'
+    | 'emphasis'
+    | 'strong'
+    | 'blockquote'
 
 export class SpellcheckTogglerSettingTab extends PluginSettingTab {
     plugin: SpellcheckTogglerPlugin
@@ -56,7 +67,7 @@ export class SpellcheckTogglerSettingTab extends PluginSettingTab {
         containerEl.empty()
 
         const createSpellcheckOptionDisplay = (
-            optionsKey: keyof SpellcheckTogglerSettings,
+            optionKey: OptionKey,
             name: string,
             description: string,
             targetFormat?: string,
@@ -81,8 +92,11 @@ export class SpellcheckTogglerSettingTab extends PluginSettingTab {
                 })
             }
 
-            const frontmatterDrawer = document.createElement('div')
-            frontmatterDrawer.className = 'frontmatter-drawer'
+            const frontmatterDrawer = settingContainer.createDiv({
+                cls: 'frontmatter-drawer',
+            })
+            //  document.createElement('div')
+            // frontmatterDrawer.className = 'frontmatter-drawer'
 
             new Setting(frontmatterDrawer)
                 .setName('Frontmatter override property')
@@ -92,13 +106,13 @@ export class SpellcheckTogglerSettingTab extends PluginSettingTab {
                 .addText((text) =>
                     text
                         .setValue(
-                            this.plugin.settings[optionsKey]
+                            this.plugin.settings[optionKey]
                                 .frontmatterOverride ?? '',
                         )
                         .onChange((frontmatterOverride) =>
                             this.plugin.saveSettings({
-                                [optionsKey]: {
-                                    ...this.plugin.settings[optionsKey],
+                                [optionKey]: {
+                                    ...this.plugin.settings[optionKey],
                                     frontmatterOverride:
                                         frontmatterOverride.length
                                             ? frontmatterOverride
@@ -117,17 +131,17 @@ export class SpellcheckTogglerSettingTab extends PluginSettingTab {
                     const { frontmatter, ...filteredOptions } =
                         SpellcheckBehaviourOptionDisplay
                     dropdown
-                        .addOptions({... filteredOptions})
+                        .addOptions({ ...filteredOptions })
                         .onChange((frontmatterFallback) => {
                             this.plugin.saveSettings({
-                                [optionsKey]: {
-                                    ...this.plugin.settings[optionsKey],
+                                [optionKey]: {
+                                    ...this.plugin.settings[optionKey],
                                     frontmatterFallback: frontmatterFallback,
                                 },
                             })
                         })
                         .setValue(
-                            this.plugin.settings[optionsKey]
+                            this.plugin.settings[optionKey]
                                 .frontmatterFallback ??
                                 SpellcheckBehaviourOption.DEFAULT,
                         )
@@ -138,7 +152,7 @@ export class SpellcheckTogglerSettingTab extends PluginSettingTab {
                 [
                     SpellcheckBehaviourOption.DEFAULT,
                     SpellcheckBehaviourOption.GLOBAL,
-                ].includes(this.plugin.settings[optionsKey].behaviour),
+                ].includes(this.plugin.settings[optionKey].behaviour),
             )
 
             new Setting(settingContainer)
@@ -148,8 +162,8 @@ export class SpellcheckTogglerSettingTab extends PluginSettingTab {
                         .addOptions(SpellcheckBehaviourOptionDisplay)
                         .onChange((behaviour) => {
                             this.plugin.saveSettings({
-                                [optionsKey]: {
-                                    ...this.plugin.settings[optionsKey],
+                                [optionKey]: {
+                                    ...this.plugin.settings[optionKey],
                                     behaviour,
                                 },
                             })
@@ -159,11 +173,11 @@ export class SpellcheckTogglerSettingTab extends PluginSettingTab {
                                     SpellcheckBehaviourOption.DEFAULT,
                                     SpellcheckBehaviourOption.GLOBAL,
                                 ].includes(
-                                    this.plugin.settings[optionsKey].behaviour,
+                                    this.plugin.settings[optionKey].behaviour,
                                 ),
                             )
                         })
-                        .setValue(this.plugin.settings[optionsKey].behaviour),
+                        .setValue(this.plugin.settings[optionKey].behaviour),
                 )
 
             settingContainer.appendChild(frontmatterDrawer)
@@ -193,6 +207,21 @@ export class SpellcheckTogglerSettingTab extends PluginSettingTab {
             text: `     "Never spellcheck": do not use spellcheck in any file for the option.`,
             cls: 'setting-item-target-label',
         })
+
+        new Setting(legendContainer)
+            .setName('Use reactive frontmatter')
+            .setDesc(
+                'Toggle for using reactive frontmatter property for spellchecks. Uses frontmatter processing which applies .',
+            )
+            .addToggle((t) =>
+                t
+                    .setValue(this.plugin.settings.useReactiveFrontmatter)
+                    .onChange((use) =>
+                        this.plugin.saveSettings({
+                            useReactiveFrontmatter: use,
+                        }),
+                    ),
+            )
 
         createSpellcheckOptionDisplay(
             'externalLinks',

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -24,7 +24,6 @@ export interface SpellcheckOption {
 }
 
 export interface SpellcheckTogglerSettings {
-    useReactiveFrontmatter: boolean
     externalLinks: SpellcheckOption
     internalLinks: SpellcheckOption
     htmlComments: SpellcheckOption
@@ -35,7 +34,6 @@ export interface SpellcheckTogglerSettings {
 }
 
 export const defaultSettings: SpellcheckTogglerSettings = {
-    useReactiveFrontmatter: false,
     externalLinks: { behaviour: SpellcheckBehaviourOption.GLOBAL },
     internalLinks: { behaviour: SpellcheckBehaviourOption.GLOBAL },
     htmlComments: { behaviour: SpellcheckBehaviourOption.DEFAULT },
@@ -95,8 +93,6 @@ export class SpellcheckTogglerSettingTab extends PluginSettingTab {
             const frontmatterDrawer = settingContainer.createDiv({
                 cls: 'frontmatter-drawer',
             })
-            //  document.createElement('div')
-            // frontmatterDrawer.className = 'frontmatter-drawer'
 
             new Setting(frontmatterDrawer)
                 .setName('Frontmatter override property')
@@ -207,21 +203,6 @@ export class SpellcheckTogglerSettingTab extends PluginSettingTab {
             text: `     "Never spellcheck": do not use spellcheck in any file for the option.`,
             cls: 'setting-item-target-label',
         })
-
-        new Setting(legendContainer)
-            .setName('Use reactive frontmatter')
-            .setDesc(
-                'Toggle for using reactive frontmatter property for spellchecks. Uses frontmatter processing which applies .',
-            )
-            .addToggle((t) =>
-                t
-                    .setValue(this.plugin.settings.useReactiveFrontmatter)
-                    .onChange((use) =>
-                        this.plugin.saveSettings({
-                            useReactiveFrontmatter: use,
-                        }),
-                    ),
-            )
 
         createSpellcheckOptionDisplay(
             'externalLinks',

--- a/src/spellchecks/apply-spellcheck-plugin.ts
+++ b/src/spellchecks/apply-spellcheck-plugin.ts
@@ -50,12 +50,8 @@ export class ApplySpellcheckAttributePluginValue implements PluginValue {
             })
 
         adds.sort((a, b) => a.from - b.from)
-        for (const { from, to } of adds) {
-            console.debug(
-                `[spellcheck-toggler] Set spellcheck to false for node range [ ${from}, ${to} ]`,
-            )
+        for (const { from, to } of adds)
             builder.add(from, to, markSpellcheckFalse)
-        }
 
         return builder.finish()
     }


### PR DESCRIPTION
Use `getFrontMatterInfo` instead of `processFrontmatter` to avoid apply Obsidian formatting in source mode.